### PR TITLE
git-extra (inputrc): remove an unused and incorrect keybinding

### DIFF
--- a/git-extra/inputrc
+++ b/git-extra/inputrc
@@ -28,7 +28,6 @@ set show-all-if-ambiguous off
 # MSYSTEM is emacs based
 $if mode=emacs
   # Common to Console & RXVT
-  "\C-?": backward-kill-line        # Ctrl-BackSpace
   "\e[2~": paste-from-clipboard     # "Ins. Key"
   "\e[5~": beginning-of-history     # Page up
   "\e[6~": end-of-history           # Page down


### PR DESCRIPTION
This PR removes one unused and incorrect keybinding from `/etc/inputrc`.

### Problem

To see the problem, for example, you can press <kbd>Ctrl-x</kbd><kbd>Ctrl-r</kbd> in a Bash session. <kbd>Ctrl-x</kbd><kbd>Ctrl-r</kbd> reloads the keybindings defined in `~/.inputrc`. After that, <kd>Backspace</kbd> will not work as expected in the Bash session; it removes the entire line before the cursor position.

This is caused by the following incorrect keybinding in `/etc/inputrc`:

```inputrc
  "\C-?": backward-kill-line        # Ctrl-BackSpace
```

Here, `"\C-?"` is not <kbd>Ctrl-BackSpace</kbd> but <kbd>Backspace</kbd>. The reason why we don't see this behavior initially (before pressing <kbd>Ctrl-x</kbd><kbd>Ctrl-r</kbd>) is that it is overwritten by another keybinding set up by Bash/Readline in the startup processes of Bash.

- This keybinding causes problems not only when <kbd>Ctrl-x</kbd><kbd>Ctrl-r</kbd>. I actually initially received a related issue at https://github.com/akinomyoga/ble.sh/issues/104 in which the strange behavior of <kbd>Backspace</kbd> was observed with the Bash configuration `ble.sh`.
- I have already sent a PR to MSYS2 which has the same line in `/etc/skel/inputrc` https://github.com/msys2/MSYS2-packages/pull/2490

### Other inputrc's in Git for Windows?

I have a question. Actually, I'm not sure where to submit the PR. In Git for Windows, it seems that there are five inputrc files:

- https://github.com/git-for-windows/build-extra/blob/main/git-extra/inputrc (this PR fixes this file)
- https://github.com/git-for-windows/git-sdk-64/blob/main/etc/inputrc
- https://github.com/git-for-windows/git-sdk-64/blob/main/etc/skel/.inputrc
- https://github.com/git-for-windows/git-sdk-32/blob/main/etc/inputrc
- https://github.com/git-for-windows/git-sdk-32/blob/main/etc/skel/.inputrc

I guessed `build-extra/git-extra/inputrc` is the upstream of `git-sdk-{64,32}/etc/inputrc`, but where is the upstream of `git-sdk-{64,32}/etc/skel/.inputrc`? Or can I directly make PRs to `git-sdk-{64,32}` to fix these four remaining `inputrc`'s?
